### PR TITLE
Change ActiveSupport::SecureRandom to ruby's  SecureRandom

### DIFF
--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -37,7 +37,7 @@ class List < ActiveRecord::Base
   private
 
   def create_token
-    self.token = strip_for_channel_name(ActiveSupport::SecureRandom.base64(8))
+    self.token = strip_for_channel_name(SecureRandom.base64(8))
   end
   
   def strip_for_channel_name(str)


### PR DESCRIPTION
ActiveSupport::SecureRandom is deprecated in 3.1 and removed in 3.2 SecureRandom should be used instead.

I got this knowledge from:

https://github.com/scambra/devise_invitable/issues/159

Not sure if this will fix will break in older versions, but I guess not.
